### PR TITLE
Obakari/responsefile types

### DIFF
--- a/client/src/components/SurveyManagement/AnswerTypes/FileUpload.js
+++ b/client/src/components/SurveyManagement/AnswerTypes/FileUpload.js
@@ -5,12 +5,53 @@ class FileUpload extends React.Component {
     //Initialize a Rounds object based on local storage
     constructor(props) {
         super(props);
+
+        this.state =  {
+          selectedOptions : []
+        };
+    }
+
+    // Handles the onchange for the selected items.
+    handleChange = (event) => {
+      let newSelectedOptions = event.target.value;
+      let selectedOptions = this.state.selectedOptions;
+  
+      console.log(selectedOptions)
+      console.log(newSelectedOptions)
+      if(selectedOptions.indexOf(newSelectedOptions) === -1)
+      {
+        selectedOptions.push(newSelectedOptions);
+      }
+      else{
+        if(selectedOptions.length === 1)
+        {
+          selectedOptions = [];
+        }
+        else{
+          selectedOptions.splice(selectedOptions.indexOf(newSelectedOptions), 1);
+        }
+      }
+
+      this.setState({ selectedOptions: selectedOptions }, ()=> { console.log(this.state.selectedOptions);});
     }
 
     render(){
         return(
             <div>
             <center>
+            <p></p>
+            <label>Acceptable File Types:
+            <select name="answerType" multiple={true} value={this.state.selectedOptions} onChange={this.handleChange} 
+              className="form-control form-center">
+              <option value=".pdf">pdf</option>
+              <option value=".docx">docx</option>
+              <option value=".jpg">jpg</option>
+              <option value=".jpeg">jpeg</option>
+              <option value=".png">png</option>
+              <option value=".doc">doc</option>                     
+            </select> 
+            </label>
+            <p></p>
               <label>
                 File:
                 <input name="filename" className="form-control form-center" 

--- a/client/src/components/SurveyManagement/AnswerTypes/FileUpload.js
+++ b/client/src/components/SurveyManagement/AnswerTypes/FileUpload.js
@@ -32,7 +32,7 @@ class FileUpload extends React.Component {
         }
       }
 
-      this.setState({ selectedOptions: selectedOptions }, ()=> { console.log(this.state.selectedOptions);});
+      this.setState({ selectedOptions: selectedOptions }, ()=> { console.log("String representation:"); console.log(this.state.selectedOptions.toString()); console.log(this.state.selectedOptions);});
     }
 
     render(){
@@ -55,7 +55,7 @@ class FileUpload extends React.Component {
               <label>
                 File:
                 <input name="filename" className="form-control form-center" 
-                  type="file"/>
+                  type="file" accept={this.state.selectedOptions.toString()}/>
               </label>
             <p></p>
             </center>

--- a/server/routes/question.js
+++ b/server/routes/question.js
@@ -17,10 +17,11 @@ router.post('/questions/:surveyID',  async (req, res, next) => {
     !req.body.hasOwnProperty("questionText") ||
     !req.body.hasOwnProperty("questionType") ||
     !req.body.hasOwnProperty("questionAnswers") || 
+    !req.body.hasOwnProperty("acceptableAnswerTypes") ||
     !req.body.hasOwnProperty("questionActive"))
     {
         return res.status(400).sent("POST request on /questions formulated incorrectly." +
-        "Body must contain all 6 required fields, questionID, quiestionTitle, questionText, questionType, questionAnswers, questionActive");
+        "Body must contain all 6 required fields, questionID, quiestionTitle, questionText, questionType, acceptableAnswerTypes, questionAnswers, questionActive");
     }
   try {
       thisSurvey = await Survey.updateOne(
@@ -47,14 +48,14 @@ router.put('/questions/:surveyID/:questionID', async (req, res, next) => {
               JSON.stringify(req.params) + " and body = " + 
               JSON.stringify(req.body));
   // Make sure only these props are being added to the database for question
-  const validProps = ['questionID', 'questionTitle','questionText', 'questionType', 'questionAnswers', 'questionActive'];
+  const validProps = ['questionID', 'questionTitle','questionText', 'questionType','acceptableAnswerTypes', 'questionAnswers', 'questionActive'];
   let bodyObj = {...req.body};
   delete bodyObj._id; //Not needed for update
   for (const bodyProp in bodyObj) {
     if (!validProps.includes(bodyProp)) {
       return res.status(400).send("questions/ PUT request formulated incorrectly." +
         "It includes " + bodyProp + ". However, only the following props are allowed: " +
-        "'questionID', 'questionTitle','questionText', 'questionType', 'questionAnswers', 'questionActive'");
+        "'questionID', 'questionTitle','questionText', 'questionType', 'acceptableAnswerTypes', 'questionAnswers', 'questionActive'");
     } else {
       bodyObj["questions.$." + bodyProp] = bodyObj[bodyProp];
       delete bodyObj[bodyProp];

--- a/server/schemas/question.js
+++ b/server/schemas/question.js
@@ -8,6 +8,7 @@ const questionsSchema = new Schema({
     questionText: {type: String, required: true},
     questionType: {type: String, required: true},
     questionAnswers: [String],
+    acceptableAnswerTypes: [String], /* Used for specifying the acceptable file types */
     questionActive: {type: Boolean, required: true},
     responses: [responseSchema]
   },


### PR DESCRIPTION
Created the UI to support only specific files to be accepted for file type questions. In addition, I added the _acceptableAnswerTypes_ property to the Questions schema and updated the routes that needed to be updated as a result of the change.

closes #38